### PR TITLE
Fix NULL pointer dereference in tgetstr function (CVE-2023-45918)

### DIFF
--- a/ncurses/tinfo/lib_termcap.c
+++ b/ncurses/tinfo/lib_termcap.c
@@ -369,6 +369,7 @@ NCURSES_SP_NAME(tgetstr) (NCURSES_SP_DCLx const char *id, char **area)
 	    result = tp->Strings[j];
 	    TR(TRACE_DATABASE, ("found match %d: %s", j, _nc_visbuf(result)));
 	    /* setupterm forces canceled strings to null */
+	    if(result != NULL) {
 	    if (VALID_STRING(result)) {
 		if (result == exit_attribute_mode
 		    && FIX_SGR0 != 0) {
@@ -381,6 +382,9 @@ NCURSES_SP_NAME(tgetstr) (NCURSES_SP_DCLx const char *id, char **area)
 		    result = *area;
 		    *area += strlen(*area) + 1;
 		}
+		}
+	    } else {
+	    TR(TRACE_DATABASE, ("tgetstr returned NULL for id: %s", id));
 	    }
 	}
     }


### PR DESCRIPTION
Description:

This PR fixes a NULL pointer dereference in the tgetstr function within lib_termcap.c. This issue was identified in CVE-2023-45918, which could cause the program to crash when invalid or unrecognized termcap capabilities were requested.

Problem:
The tgetstr function could return a NULL pointer when an invalid capability was passed, and this pointer was not checked before dereferencing it. This resulted in potential crashes due to memory access violations.

Solution:
Added a check for NULL before dereferencing the result of tgetstr.
If the result is NULL, the function now handles the error gracefully instead of attempting to dereference the invalid pointer.